### PR TITLE
Fix listing page import and update README

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+MONGODB_URI=mongodb+srv://<username>:<password>@cluster.mongodb.net/sellingdubai

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.next
+.env.local

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# sellingdubai
+# Selling Dubai
+
+This is a minimal Next.js project that demonstrates a property listings marketplace.
+
+## Development
+
+Install dependencies and run the development server:
+
+```
+npm install
+npm run dev
+```
+
+**Note:** The environment used by Codex does not have internet access. If `npm install` fails with a network error, run the install step on a machine with internet access or provide the required modules manually.
+
+Create a `.env.local` file based on `.env.example` and provide your MongoDB connection string.

--- a/models/Listing.js
+++ b/models/Listing.js
@@ -1,0 +1,10 @@
+import mongoose from 'mongoose';
+
+const ListingSchema = new mongoose.Schema({
+  title: String,
+  price: String,
+  description: String,
+  image: String,
+});
+
+export default mongoose.models.Listing || mongoose.model('Listing', ListingSchema);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "selling-dubai",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest",
+    "mongoose": "latest"
+  },
+  "devDependencies": {
+    "tailwindcss": "latest"
+  }
+}

--- a/pages/admin.js
+++ b/pages/admin.js
@@ -1,0 +1,28 @@
+import { useState } from 'react';
+
+export default function Admin() {
+  const [form, setForm] = useState({ title: '', price: '', description: '', image: '' });
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    await fetch('/api/listings', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form),
+    });
+    alert('Listing added!');
+  }
+
+  return (
+    <div className="container mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">Admin - Add Listing</h1>
+      <form onSubmit={handleSubmit} className="flex flex-col space-y-2">
+        <input placeholder="Title" className="border p-2 rounded" onChange={e=>setForm({...form, title:e.target.value})} />
+        <input placeholder="Price" className="border p-2 rounded" onChange={e=>setForm({...form, price:e.target.value})} />
+        <input placeholder="Image URL" className="border p-2 rounded" onChange={e=>setForm({...form, image:e.target.value})} />
+        <textarea placeholder="Description" className="border p-2 rounded" onChange={e=>setForm({...form, description:e.target.value})} />
+        <button className="bg-black text-white p-2 rounded">Save</button>
+      </form>
+    </div>
+  );
+}

--- a/pages/api/listings.js
+++ b/pages/api/listings.js
@@ -1,0 +1,14 @@
+import dbConnect from '../../utils/dbConnect';
+import Listing from '../../models/Listing';
+
+export default async function handler(req, res) {
+  await dbConnect();
+  if (req.method === 'GET') {
+    const listings = await Listing.find();
+    res.json(listings);
+  } else if (req.method === 'POST') {
+    const listing = new Listing(req.body);
+    await listing.save();
+    res.json(listing);
+  }
+}

--- a/pages/api/listings/[id].js
+++ b/pages/api/listings/[id].js
@@ -1,0 +1,8 @@
+import dbConnect from '../../../utils/dbConnect';
+import Listing from '../../../models/Listing';
+
+export default async function handler(req, res) {
+  await dbConnect();
+  const listing = await Listing.findById(req.query.id);
+  res.json(listing);
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,0 +1,28 @@
+import Link from 'next/link';
+
+export default function Home({ listings }) {
+  return (
+    <div className="container mx-auto p-4">
+      <h1 className="text-3xl font-bold mb-4">Selling Dubai Luxury Marketplace</h1>
+      <Link href="/admin">
+        <button className="bg-black text-white rounded p-2">Admin Panel</button>
+      </Link>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-6">
+        {listings.map((item) => (
+          <div key={item._id} className="border rounded p-4 shadow">
+            <img src={item.image} alt={item.title} className="w-full h-48 object-cover rounded" />
+            <h2 className="text-xl font-semibold mt-2">{item.title}</h2>
+            <p>{item.price}</p>
+            <Link href={`/listing/${item._id}`} className="text-blue-500">View Details</Link>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export async function getServerSideProps() {
+  const res = await fetch("http://localhost:3000/api/listings");
+  const listings = await res.json();
+  return { props: { listings } };
+}

--- a/pages/listing/[id].js
+++ b/pages/listing/[id].js
@@ -1,0 +1,22 @@
+
+export default function Listing({ listing }) {
+  return (
+    <div className="container mx-auto p-4">
+      <img src={listing.image} className="w-full h-96 object-cover rounded" />
+      <h1 className="text-3xl font-bold mt-4">{listing.title}</h1>
+      <p className="text-xl mt-2">{listing.price}</p>
+      <p className="mt-4">{listing.description}</p>
+      <form className="mt-4">
+        <input type="text" placeholder="Your name" className="border p-2 rounded mr-2" />
+        <input type="email" placeholder="Your email" className="border p-2 rounded mr-2" />
+        <button className="bg-black text-white p-2 rounded">Request Info</button>
+      </form>
+    </div>
+  );
+}
+
+export async function getServerSideProps(context) {
+  const res = await fetch(`http://localhost:3000/api/listings/${context.params.id}`);
+  const listing = await res.json();
+  return { props: { listing } };
+}

--- a/utils/dbConnect.js
+++ b/utils/dbConnect.js
@@ -1,0 +1,17 @@
+import mongoose from 'mongoose';
+
+const MONGODB_URI = process.env.MONGODB_URI;
+
+if (!MONGODB_URI) throw new Error('Please define MONGODB_URI in your .env.local');
+
+let cached = global.mongoose;
+if (!cached) cached = global.mongoose = { conn: null, promise: null };
+
+export default async function dbConnect() {
+  if (cached.conn) return cached.conn;
+  if (!cached.promise) {
+    cached.promise = mongoose.connect(MONGODB_URI, { bufferCommands: false }).then(m => m);
+  }
+  cached.conn = await cached.promise;
+  return cached.conn;
+}


### PR DESCRIPTION
## Summary
- remove unused `useRouter` import from listing page
- explain offline install requirements in README

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_685e71a3ea348329864b26fc6121c3af